### PR TITLE
Fix formatting syntax in nightly report script

### DIFF
--- a/scripts/prompt_processing_summary.py
+++ b/scripts/prompt_processing_summary.py
@@ -82,7 +82,7 @@ def make_summary_message(day_obs, instrument):
     )
     if groups_without_events:
         output_lines.append(
-            f"{len(groups_without_events)} raws had no nextVisit: {",".join(groups_without_events)}"
+            f"{len(groups_without_events)} raws had no nextVisit: {', '.join(groups_without_events)}"
         )
     if len(raw_exposures) == 0:
         return "\n".join(output_lines)


### PR DESCRIPTION
## Summary
- fix the `groups_without_events` Slack message formatting

## Testing
- `python -m py_compile scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_b_685dc79338dc832387a5522a3f1c10b4