### PR TITLE
Handle Loki query failures

### DIFF
--- a/scripts/queries.py
+++ b/scripts/queries.py
@@ -132,9 +132,9 @@ def query_loki(day_obs, container_name, search_string):
 
     result = subprocess.run(command, capture_output=True, text=True)
     if result.returncode != 0:
-        _log.error("Loki query failed")
-        _log.error(result.stderr)
-        return
+        error_msg = f"Loki query failed: {result.stderr.strip()}"
+        _log.error(error_msg)
+        raise RuntimeError(error_msg)
 
     return result.stdout
 


### PR DESCRIPTION
## Summary
- raise an error from `query_loki` when the logcli command fails
- remove downstream None handling added previously

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685ecc55599c832399333874a734d798