### PR TITLE
Clarify docstring for match_string2

### DIFF
--- a/scripts/queries.py
+++ b/scripts/queries.py
@@ -197,7 +197,7 @@ def get_df_from_loki(
     match_string : `str`
         Loki stream selector for Loki query.
     match_string2 : `str`
-        Loki stream selector for Loki query.
+        Additional search/filter expression for the Loki query.
 
     Returns
     -------


### PR DESCRIPTION
## Summary
- clarify description of `match_string2` in `get_df_from_loki`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_685f25a79cdc8323bf42483560ae8ff6