### PR TITLE
Fix test import path

### DIFF
--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,13 +1,16 @@
 import json
+import os
 import sys
 import unittest
 
 import pandas
 from pandas.testing import assert_frame_equal
 
-from queries import parse_loki_results
+sys.path.append(
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "scripts"))
+)
 
-sys.path.append("../scripts/")
+from queries import parse_loki_results
 
 
 class LokiResultsParsingTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- fix sys.path modification to use path before importing `parse_loki_results`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_685f25b10f248323a2cfdb496acf3800