### PR TITLE
Handle detector counts per instrument

### DIFF
--- a/scripts/prompt_processing_summary.py
+++ b/scripts/prompt_processing_summary.py
@@ -12,6 +12,13 @@ from queries import (
     get_df_from_loki,
 )
 
+# Total number of detectors per instrument
+INSTRUMENT_DETECTORS = {
+    "LSSTCam": 189,
+    "LSSTComCam": 9,
+    "LATISS": 1,
+}
+
 
 def make_summary_message(day_obs, instrument):
     """Make Prompt Processing summary message for a night
@@ -37,6 +44,11 @@ def make_summary_message(day_obs, instrument):
         get_next_visit_events(day_obs, instrument, survey)
     )
     total_visit_count = len(next_visits)
+
+    total_detectors = INSTRUMENT_DETECTORS.get(instrument, 0)
+    off_detector = 18 if instrument == "LSSTCam" else 0
+    active_detectors = total_detectors - off_detector
+    expected_preprocessing = total_visit_count * active_detectors
     canceled_list = next_visits.index.intersection(
         canceled_visits.set_index("groupId").index
     ).tolist()
@@ -67,6 +79,8 @@ def make_summary_message(day_obs, instrument):
     )
     groups = [r.group for r in raw_exposures]
     groups_without_events = set(groups) - set(next_visits.reset_index()["groupId"])
+
+    expected = (len(raw_exposures) - len(groups_without_events)) * active_detectors
 
     raw_counts = count_datasets(
         butler_nocollection,
@@ -136,9 +150,7 @@ def make_summary_message(day_obs, instrument):
     )
     missed = 0
     counted = 0
-    # LSSTCam number of active detector is hard-coded here.
     if instrument == "LSSTCam":
-        off_detector = 18
         df = get_df_from_loki(
             day_obs,
             instrument=instrument,
@@ -146,12 +158,9 @@ def make_summary_message(day_obs, instrument):
             match_string2="",
         )
         output_lines.append(
-            f"Number of expected preprocessing: {total_visit_count} nextVisits*(189-{off_detector} detectors)={total_visit_count * (189-off_detector)}. Successful: {len(df)}. "
+            f"Number of expected preprocessing: {total_visit_count} nextVisits*({total_detectors}-{off_detector} detectors)={expected_preprocessing}. Successful: {len(df)}. "
         )
-        expected = (len(raw_exposures) - len(groups_without_events)) * (
-            189 - off_detector
-        )
-        missed = expected - len(log_visit_detector)
+    missed = expected - len(log_visit_detector)
 
     df, count_total = _get_filtered_loki_df(
         day_obs, instrument, groups, match_string='|= "Timed out waiting for image"'
@@ -224,7 +233,7 @@ def make_summary_message(day_obs, instrument):
         output_lines.append(f"- {len(df)} Timed out connecting to raw microservice.")
 
     output_lines.append(
-        f"Number of expected processing: ({len(raw_exposures)}-{len(groups_without_events)}) raws*(189-{off_detector} detectors)={expected:d}. Missed {missed}"
+        f"Number of expected processing: ({len(raw_exposures)}-{len(groups_without_events)}) raws*({total_detectors}-{off_detector} detectors)={expected:d}. Missed {missed}"
     )
     df, _ = _get_filtered_loki_df(
         day_obs,


### PR DESCRIPTION
## Summary
- add `INSTRUMENT_DETECTORS` map for detector counts
- use instrument-specific default `off_detector`
- compute `expected` and preprocessing counts with active detectors
- update status messages to use the calculated values

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_685f218552088323b6422b5b2f2383d3