### PR TITLE
Remove unused dataclass import

### DIFF
--- a/scripts/prompt_processing_summary.py
+++ b/scripts/prompt_processing_summary.py
@@ -2,7 +2,6 @@ import asyncio
 import sys
 import os
 import lsst.daf.butler as dafButler
-from dataclasses import dataclass
 from datetime import date, timedelta
 import requests
 


### PR DESCRIPTION
## Summary
- clean up `prompt_processing_summary.py` by removing unused dataclass import

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_685f21704efc8323b141499c4ce4c0c7